### PR TITLE
添加 .gitignore 与 .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig: http://editorconfig.org
+
+# top-most .editorconfig
+root = true
+
+# All files
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+
+# For markdown files
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# OS generated files
+## MacOS
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+._*
+.Trashes
+## Windows
+ehthumbs.db
+Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# Vim
+Session.vim
+*~
+*.s[a-w][a-z]
+*.un~
+
+# Sublime
+*.sublime-workspace
+*.sublime-project
+
+# IntelliJ (WebStorm)
+.idea


### PR DESCRIPTION
* `.gitignore` 覆盖了 MacOS 与 Windows 系统以及 Sublime, Vim 和 IntelliJ 系列的常见需忽略文件
* `.editorconfig` 添加了格式建议，所有文件均采用 4 空格缩进
* 除`markdown` 文件外，其他文件均移除多余的空行缩进 (Trailing White Space)